### PR TITLE
media.cpp: prevent AudioMediaPlayer destructor from doubly removing port

### DIFF
--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -275,6 +275,7 @@ AudioMediaPlayer::AudioMediaPlayer()
 AudioMediaPlayer::~AudioMediaPlayer()
 {
     if (playerId != PJSUA_INVALID_ID) {
+        id = PJSUA_INVALID_ID;
         unregisterMediaPort();
         pjsua_player_destroy(playerId);
     }


### PR DESCRIPTION
The `AudioMediaPlayer` destructor has an issue where it effectively destroys the player's conference port twice, in a thread-unsafe way that leaves an opportunity for another thread to see a conference port used by a player as free-for-use, and reserve it for other purposes before ultimately being destroyed again, causing crashes.

We see this race condition ~1 in 5 times when attempting to disrupt an ongoing call with a talkdown call, where `StopTransmit()` is interrupted by the PJSIP thread answering the incoming call.

Here's an example of how this can happen: 
```
AudioMediaPlayer::~AudioMediaPlayer()
{
    if (playerId != PJSUA_INVALID_ID) {
        // Example: media player is using slot 2, aka pjsua_var.player[playerId].slot == 2

        unregisterMediaPort(); <----- calls pjsua_conf_remove_port() which removes slot 2, but does not de-init/clear pjsua_var.player[playerId].slot

        // INCOMING CALL THREAD OCCURS HERE - finds any empty conf port and adds a new port for the incoming call, sees slot 2 is free and sets up port there

        pjsua_player_destroy(playerId); <----- also calls pjsua_conf_remove_port() on pjsua_var.player[playerId].slot, which still == 2
        
        // This removes the now-active talkdown port, program crashes on talkdown connect audio
    }
}
```

The approach taken in this PR to fix this problem is taken from a pattern used elsewhere in media.cpp presumably to prevent this exact problem - invalidating the `AudioMedia` `id` such that `unregisterMediaPort()` does not attempt to remove the port unnecessarily: https://github.com/verkada/pjproject/blob/7eec09d2f1ab6b40d7b447d40c62c47e53880e44/pjsip/src/pjsua2/media.cpp#L665-L670

Relevant segment of `unregisterMediaPort()`: https://github.com/verkada/pjproject/blob/7eec09d2f1ab6b40d7b447d40c62c47e53880e44/pjsip/src/pjsua2/media.cpp#L177-L182

This ensures that the only attempt to remove an `AudioMediaPlayer`'s port occurs in `pjsua_player_destroy()`, therefore guaranteeing that `pjsua_player_destroy()` does not delete a now-occupied port mistakenly.
