### PR TITLE
INT-2698: Potential fix for audio jitter issues

### DIFF
--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -513,6 +513,24 @@ static int pb_thread_func (void *arg)
     char* buf                  = stream->pb_buf;
     pj_timestamp tstamp;
     int result;
+    struct sched_param param;
+    pthread_t* thid;
+
+    thid = (pthread_t*) pj_thread_get_os_handle (pj_thread_this());
+    param.sched_priority = sched_get_priority_max (SCHED_RR);
+    PJ_LOG (5,(THIS_FILE, "pb_thread_func(%u): Set thread priority "
+                          "for audio capture thread.",
+                          (unsigned)syscall(SYS_gettid)));
+    result = pthread_setschedparam (*thid, SCHED_RR, &param);
+    if (result) {
+        if (result == EPERM)
+            PJ_LOG (5,(THIS_FILE, "Unable to increase thread priority, "
+                                  "root access needed."));
+        else
+            PJ_LOG (5,(THIS_FILE, "Unable to increase thread priority, "
+                                  "error: %d",
+                                  result));
+    }
 
     pj_bzero (buf, size);
     tstamp.u64 = 0;

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -540,7 +540,7 @@ static int pb_thread_func (void *arg)
 
         result = snd_pcm_writei (pcm, buf, nframes);
         if (result == -EPIPE) {
-            PJ_LOG (4,(THIS_FILE, "pb_thread_func: underrun!"));
+            PJ_LOG (1,(THIS_FILE, "pb_thread_func: underrun!"));
             snd_pcm_prepare (pcm);
         } else if (result < 0) {
             PJ_LOG (4,(THIS_FILE, "pb_thread_func: error writing data!"));

--- a/pjmedia/src/pjmedia-audiodev/alsa_dev.c
+++ b/pjmedia/src/pjmedia-audiodev/alsa_dev.c
@@ -1083,7 +1083,7 @@ static pj_status_t alsa_stream_start (pjmedia_aud_stream *s)
 
     if (stream->param.dir & PJMEDIA_DIR_CAPTURE) {
         status = pj_thread_create (stream->pool,
-                                   "alsasound_playback",
+                                   "alsasound_capture",
                                    ca_thread_func,
                                    stream,
                                    0, //ZERO,


### PR DESCRIPTION
The Linux kernel supports "real-time" scheduling priorities which supersede the normal priority levels accessible by adjusting "nice" values. See: https://wiki.linuxfoundation.org/realtime/documentation/technical_basics/sched_policy_prio/start

The upstream project had already instituted a real-time priority for the ALSA capture thread, but the playback thread was left for default scheduling. This change copies the same scheduling change over to the playback thread.