### PR TITLE
pjsua2: media: Implement AudioMediaPlayer::invalidatePlayer call

### DIFF
--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -542,6 +542,10 @@ public:
      */
     virtual ~AudioMediaPlayer();
 
+    /**
+     * Reset to initial state. Prevents any future callbacks from firing.
+     */
+    void invalidatePlayer();
 public:
     /*
      * Callbacks

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -409,6 +409,15 @@ void AudioMediaPlayer::eof_cb(pjmedia_port *port,
     player->onEof2();
 }
 
+void AudioMediaPlayer::invalidatePlayer()
+{
+    // Hack: call the destructor directly (avoiding virtual dispatch) to clean up resources
+    // and ensure onEof() callback is not invoked from this point on.
+    this->AudioMediaPlayer::~AudioMediaPlayer();
+    // Prevent the destructor from running its logic again
+    playerId = PJSUA_INVALID_ID;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 AudioMediaRecorder::AudioMediaRecorder()
 : recorderId(PJSUA_INVALID_ID)


### PR DESCRIPTION
This allows us to work around an impedance mismatch with SWIG, which generates a destructor in its subclass. The AudioMediaPlayer destructor is responsible for ensuring that callbacks are no longer invoked after teardown has begun, but SWIG's destructor runs earlier and removes the mapping for the instance. That leaves a small window where the onEof() callback may be invoked, causing a crash.

This change exposes a method that may be called from Go in order to invoke that destructor logic prior to SWIG removing its mapping, thus eliminating the possible race.