### PR TITLE
INT-5762: ALSA snd device pause and add onSndDevOperation callback

### DIFF
--- a/pjsip/include/pjsua2/endpoint.hpp
+++ b/pjsip/include/pjsua2/endpoint.hpp
@@ -1813,6 +1813,9 @@ public:
                         const OnTransportStateParam &prm)
     { PJ_UNUSED_ARG(prm); }
 
+    virtual pj_status_t onSndDevOperation(int operation)
+    { PJ_UNUSED_ARG(operation); return PJ_SUCCESS; }
+
     /**
      * Callback when a timer has fired. The timer was scheduled by
      * utilTimerSchedule().
@@ -1928,6 +1931,7 @@ private:
     static void on_transport_state(pjsip_transport *tp,
                                    pjsip_transport_state state,
                                    const pjsip_transport_state_info *info);
+    static pj_status_t on_snd_dev_operation(int operation);
 
 private:
     /*

--- a/pjsip/src/pjsua-lib/pjsua_aud.c
+++ b/pjsip/src/pjsua-lib/pjsua_aud.c
@@ -460,7 +460,7 @@ void pjsua_check_snd_dev_idle()
      * there is no active call.
      */
     if (pjsua_var.snd_idle_timer.id == PJ_FALSE &&
-        call_cnt == 0 &&
+        call_cnt <= 1 &&
         pjmedia_conf_get_connect_count(pjsua_var.mconf) == 0)
     {
         pj_time_val delay;
@@ -482,7 +482,7 @@ static void close_snd_timer_cb( pj_timer_heap_t *th,
 
     PJSUA_LOCK();
     if (entry->id) {
-        PJ_LOG(4,(THIS_FILE,"Closing sound device after idle for %d second(s)",
+        PJ_LOG(2,(THIS_FILE,"Closing sound device after idle for %d second(s)",
                   pjsua_var.media_cfg.snd_auto_close_time));
 
         entry->id = PJ_FALSE;

--- a/pjsip/src/pjsua2/endpoint.cpp
+++ b/pjsip/src/pjsua2/endpoint.cpp
@@ -1258,6 +1258,11 @@ void Endpoint::on_stream_created2(pjsua_call_id call_id,
     param->port = (pjmedia_port *)prm.pPort;
 }
 
+pj_status_t Endpoint::on_snd_dev_operation(int operation) {
+    Endpoint &ep = Endpoint::instance();
+    return ep.onSndDevOperation(operation);
+}
+
 void Endpoint::on_stream_destroyed(pjsua_call_id call_id,
                                    pjmedia_stream *strm,
                                    unsigned stream_idx)
@@ -1906,6 +1911,7 @@ void Endpoint::libInit(const EpConfig &prmEpConfig) PJSUA2_THROW(Error)
     pj_bzero(&ua_cfg.cb, sizeof(ua_cfg.cb));
     ua_cfg.cb.on_nat_detect     = &Endpoint::on_nat_detect;
     ua_cfg.cb.on_transport_state = &Endpoint::on_transport_state;
+    ua_cfg.cb.on_snd_dev_operation = &Endpoint::on_snd_dev_operation;
 
     ua_cfg.cb.on_incoming_call  = &Endpoint::on_incoming_call;
     ua_cfg.cb.on_reg_started    = &Endpoint::on_reg_started;


### PR DESCRIPTION
Allow the ALSA device to be closed if unused, for when we are in a livekit call. Add `onSndDevOperation` callback for pjsua2 Endpoint, allowing library users to detect when the alsa device is closed, and when it is opened.