### PR TITLE
INT: PJSUA2: Hold a reference to tx_data in SipTxData::fromPj to prevent use-after-free

### DIFF
--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -701,7 +701,17 @@ SipTxData::SipTxData()
 void SipTxData::fromPj(pjsip_tx_data &tdata)
 {
     char straddr[PJ_INET6_ADDRSTRLEN+10];
-    
+
+    /* Hold a reference to the tx_data for the duration of this function.
+     * This is invoked from event callbacks (e.g. on_tsx_state) that may run
+     * on a worker thread and, in transaction termination/transport error
+     * paths, after the transaction group lock has been released. Without a
+     * reference the tx_data (and its pool) can be freed concurrently, causing
+     * a crash inside pjsip_tx_data_encode()/pjsip_msg_print() while the
+     * message is being encoded below.
+     */
+    pjsip_tx_data_add_ref(&tdata);
+
     info        = pjsip_tx_data_get_info(&tdata);
     pjsip_tx_data_encode(&tdata);
     wholeMsg    = string(tdata.buf.start, tdata.buf.cur - tdata.buf.start);
@@ -712,6 +722,8 @@ void SipTxData::fromPj(pjsip_tx_data &tdata)
         dstAddress = "";
     }
     pjTxData    = (void *)&tdata;
+
+    pjsip_tx_data_dec_ref(&tdata);
 }
 
 SipTransaction::SipTransaction()


### PR DESCRIPTION
## Summary

Cherry-pick of [pjsip/pjproject#5005](https://github.com/pjsip/pjproject/pull/5005).

`SipTxData::fromPj()` calls `pjsip_tx_data_encode()` and reads `tdata.buf` on a `pjsip_tx_data` received by reference from event callbacks (e.g. `on_tsx_state`) without holding a reference. On a multi-threaded endpoint, the transaction group lock is released around the callback, creating a window where the `pjsip_tx_data` and its pool can be freed concurrently while `fromPj()` is still encoding it — causing a use-after-free crash inside `pjsip_msg_print()`.

**Fix:** Acquire a reference to `tx_data` for the duration of `fromPj()` via `pjsip_tx_data_add_ref()` / `pjsip_tx_data_dec_ref()`, following the existing PJSUA2 pattern used in `endpoint.cpp` for `AuthChallenge`.

## Crash

```
Crash reason:  SIGSEGV /SEGV_MAPERR
Crash address: 0x0
Process uptime: not available

Thread 12 (crashed)
 0  libc.so.6 + 0x9a39c
    Found by: given as instruction pointer in context
 1  libpjsip.so.2!pjsip_msg_print [string_fortified.h : 29 + 0x0]
    Found by: previous frame's frame pointer
 2  0x397626ec
    Found by: call frame info
 3  libpjsua2.so.2!pj::SipTxData::fromPj(pjsip_tx_data&) [siptypes.cpp : 706 + 0x4]
    Found by: stack scanning
```

## Changes

- `pjsip/src/pjsua2/siptypes.cpp`: add `pjsip_tx_data_add_ref` / `pjsip_tx_data_dec_ref` around the encode call in `SipTxData::fromPj()`
