### PR TITLE
INT-10169: Cherry-pick upstream pjproject fixes (PR #5033, #5037)

### DIFF
--- a/pjsip/include/pjsua2/siptypes.hpp
+++ b/pjsip/include/pjsua2/siptypes.hpp
@@ -153,6 +153,12 @@ public:
     /** Construct a socket option with the specified parameters. */
     SockOpt(int level, int optName, int optVal);
 
+    /** Copy constructor. */
+    SockOpt(const SockOpt &that);
+
+    /** Copy assignment operator. */
+    SockOpt& operator=(const SockOpt &that);
+
     /**
      * Set option value of type integer.
      *

--- a/pjsip/src/pjsua-lib/pjsua_acc.c
+++ b/pjsip/src/pjsua-lib/pjsua_acc.c
@@ -2488,6 +2488,27 @@ static void regc_cb(struct pjsip_regc_cbparam *param)
         PJ_LOG(2, (THIS_FILE, "SIP registration failed, status=%d (%.*s)", 
                    param->code, 
                    (int)param->reason.slen, param->reason.ptr));
+
+        /* Transaction timeout (no response, rdata==NULL) over a reliable
+         * transport may mean the connection was silently dropped. Shut it
+         * down to force a reconnect on the next registration. A real 408
+         * response (rdata!=NULL) means the connection is alive, so skip it.
+         */
+        if (param->code == PJSIP_SC_REQUEST_TIMEOUT && param->rdata == NULL) {
+            pjsip_regc_info reginfo;
+
+            pjsip_regc_get_info(param->regc, &reginfo);
+            if (reginfo.transport &&
+                (reginfo.transport->flag & PJSIP_TRANSPORT_RELIABLE))
+            {
+                PJ_LOG(3, (THIS_FILE,
+                           "Registration timed out, shutting down transport "
+                           "%s to force a reconnect on next registration",
+                           reginfo.transport->obj_name));
+                pjsip_transport_shutdown(reginfo.transport);
+            }
+        }
+
         destroy_regc(acc, PJ_TRUE);
 
         /* Clear Service-Route header */

--- a/pjsip/src/pjsua2/siptypes.cpp
+++ b/pjsip/src/pjsua2/siptypes.cpp
@@ -315,6 +315,26 @@ SockOpt::SockOpt(int level, int optName, int optVal)
     setOptValInt(optVal);
 }
 
+SockOpt::SockOpt(const SockOpt &that)
+{
+    *this = that;
+}
+
+SockOpt& SockOpt::operator=(const SockOpt &that)
+{
+    if (this == &that)
+        return *this;
+
+    level = that.level;
+    optName = that.optName;
+    optLen = that.optLen;
+    optValInt = that.optValInt;
+    /* Re-point to our own optValInt if 'that' used its internal buffer. */
+    optVal = (that.optVal == &that.optValInt) ? &optValInt : that.optVal;
+
+    return *this;
+}
+
 void SockOpt::setOptValInt(int opt_val)
 {
     optVal = &optValInt;


### PR DESCRIPTION
Cherry-picks two upstream pjproject fixes onto `intercom/release-2-15`.

## Commits

- **pjsua-lib: Reconnect on registration timeout over reliable transport**
  Upstream PR: https://github.com/pjsip/pjproject/pull/5033

- **pjsua2: Fix SockOpt copy semantics so optVal isn't left aliased**
  Upstream PR: https://github.com/pjsip/pjproject/pull/5037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
